### PR TITLE
allow applying time zone cmd line arg to data

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ poetry run era5epw_download --year 2024 --latitude 49.4 --longitude 0.1 --city-n
 era5epw_download --year 2024 --latitude 49.4 --longitude 0.1 --city-name "Le Havre" --elevation 0 --time-zone 1
 ```
 
+By default, the `time-zone` argument is used only to populate the `LOCATION` header and data time is UTC. Use `--apply-time-zone-to-data` to apply it to the date and time fields (this will shift the UTC time by the provided time zone offset).
+
 Use `--help` to have a list of available options.
 
 # Documentation

--- a/era5epw/ads.py
+++ b/era5epw/ads.py
@@ -32,17 +32,14 @@ def make_cams_solar_radiation_request(
     if year > now.year:
         return None  # Do not allow requests for future years
 
-    start_day = f"{year}-01-01"
+    # We start fetching at year - 1 even if time_zone is None as CAMS data starts at 01:00 UTC
+    start_day = f"{year - 1}-12-31"
     end_day = f"{year}-12-31"
-    today = now.strftime("%Y-%m-%d")
-
     # Adjust date range based on time zone if provided
-    if time_zone is not None:
-        if time_zone > 0:
-            start_day = f"{year - 1}-12-31"
-        elif time_zone < 0:
-            end_day = f"{year + 1}-01-01"
+    if time_zone is not None and time_zone < 0:
+        end_day = f"{year + 1}-01-01"
 
+    today = now.strftime("%Y-%m-%d")
     if end_day > today:
         end_day = today
 

--- a/era5epw/cds.py
+++ b/era5epw/cds.py
@@ -105,7 +105,7 @@ def make_cds_request(
         # Adjust date range based on time zone if provided.
         # We append an additional 1-day request to cover the shifted time zone
         if time_zone is not None:
-            if time_zone > 0 and month_start == 1:
+            if time_zone >= 0 and month_start == 1:
                 start_date_str = f"{year - 1}-12-31"
                 end_date_str = f"{year - 1}-12-31"
             elif time_zone < 0 and month_end == 12:
@@ -117,6 +117,11 @@ def make_cds_request(
             tz_request = main_request.copy()
             tz_request["date"] = [f"{start_date_str}/{end_date_str}"]
             return [main_request, tz_request]
+
+        elif time_zone is None and month_start == 1:
+            prev_day_request = main_request.copy()
+            prev_day_request["date"] = [f"{year - 1}-12-31/{year - 1}-12-31"]
+            return [prev_day_request, main_request]
 
         else:
             return [main_request]
@@ -140,7 +145,7 @@ def make_cds_request(
 
         # extend the request to cover time zone shifts
         if time_zone is not None:
-            if time_zone > 0 and month_start == 1:
+            if time_zone >= 0 and month_start == 1:
                 tz_request = main_request.copy()
                 tz_request["year"] = [str(year - 1)]
                 tz_request["month"] = ["12"]
@@ -152,6 +157,14 @@ def make_cds_request(
                 tz_request["month"] = ["01"]
                 tz_request["day"] = ["01"]
                 return [main_request, tz_request]
+
+        # add previous year's last day to fetch 00:00
+        elif time_zone is None and month == 1:
+            prev_day_request = main_request.copy()
+            prev_day_request["year"] = [str(year - 1)]
+            prev_day_request["month"] = ["12"]
+            prev_day_request["day"] = ["31"]
+            return [prev_day_request, main_request]
 
         return [main_request]
 

--- a/era5epw/main.py
+++ b/era5epw/main.py
@@ -179,11 +179,12 @@ def download_and_make_epw(
         era5_df.index = era5_df.index + pd.Timedelta(hours=time_zone)
         cams_df.index = cams_df.index + pd.Timedelta(hours=time_zone)
 
-        # Filter to keep only data within the target year in the local time zone
-        series_start = f"{year}-01-01 00:00:00"
-        series_end = f"{year}-12-31 23:00:00"
-        era5_df = era5_df.truncate(before=series_start, after=series_end)
-        cams_df = cams_df.truncate(before=series_start, after=series_end)
+    # Filter to keep only data within the target year
+    # (filters out extra days added for time zone or to accommodate with missing first hour)
+    series_start = f"{year}-01-01 00:00:00"
+    series_end = f"{year}-12-31 23:00:00"
+    era5_df = era5_df.truncate(before=series_start, after=series_end)
+    cams_df = cams_df.truncate(before=series_start, after=series_end)
 
     # Align ERA5 and CAMS dataframes to the same time range
     # their indices may not match exactly, especially when the year is not complete (e.g. current year)
@@ -327,5 +328,5 @@ if __name__ == "__main__":
         output_file=f"/tmp/era5epw_{datetime.now().strftime('%Y%m%d_%H%M%S')}.epw",
         parallel_exec_nb=10,
         verbose=False,
-        apply_time_zone_to_data=True,
+        apply_time_zone_to_data=False,
     )

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -20,7 +20,7 @@ class TestADS(unittest.TestCase):
         self.assertEqual(request["location"]["longitude"], 10.0)
         self.assertEqual(request["location"]["latitude"], 50.0)
         self.assertEqual(request["altitude"], ["0"])
-        self.assertEqual(request["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(request["date"], ["2020-12-31/2021-12-31"])
         self.assertEqual(request["time_step"], "1hour")
         self.assertEqual(request["time_reference"], "universal_time")
         self.assertEqual(request["format"], "netcdf")
@@ -38,7 +38,7 @@ class TestADS(unittest.TestCase):
         )
 
         self.assertEqual(
-            request["date"], [f"{now.year}-01-01/{now.year}-{now.month:02d}-{now.day:02d}"]
+            request["date"], [f"{now.year - 1}-12-31/{now.year}-{now.month:02d}-{now.day:02d}"]
         )
 
     def test_make_cams_solar_radiation_request_future_year(self):

--- a/tests/test_cds.py
+++ b/tests/test_cds.py
@@ -6,22 +6,29 @@ from era5epw.utils import now_utc
 
 class TestCDS(unittest.TestCase):
     def test_make_cds_request_era5_single_levels(self):
-        request = make_cds_request(
+        requests = make_cds_request(
             ds="reanalysis-era5-single-levels",
             variables=["2m_temperature", "10m_u_component_of_wind"],
             year=2021,
             month=1,
             latitude=50.0,
             longitude=10.0,
-        )[0]
+        )
+        self.assertEqual(len(requests), 2)
 
-        self.assertEqual(request["dataset"], "reanalysis-era5-single-levels")
-        self.assertIn("2m_temperature", request["variable"])
-        self.assertIn("10m_u_component_of_wind", request["variable"])
-        self.assertEqual(request["year"], ["2021"])
-        self.assertEqual(request["month"], ["01"])
-        self.assertEqual(request["day"], [f"{d:02d}" for d in list(range(1, 32))])
-        self.assertEqual(request["area"], [50.0, 10.0, 50.0, 10.0])
+        prev_day_request = requests[0]
+        self.assertEqual(prev_day_request["year"], ["2020"])
+        self.assertEqual(prev_day_request["month"], ["12"])
+        self.assertEqual(prev_day_request["day"], ["31"])
+
+        main_request = requests[1]
+        self.assertEqual(main_request["dataset"], "reanalysis-era5-single-levels")
+        self.assertIn("2m_temperature", main_request["variable"])
+        self.assertIn("10m_u_component_of_wind", main_request["variable"])
+        self.assertEqual(main_request["year"], ["2021"])
+        self.assertEqual(main_request["month"], ["01"])
+        self.assertEqual(main_request["day"], [f"{d:02d}" for d in list(range(1, 32))])
+        self.assertEqual(main_request["area"], [50.0, 10.0, 50.0, 10.0])
 
     def test_make_cds_request_era5_single_levels_current_month(self):
         now = now_utc()
@@ -58,24 +65,29 @@ class TestCDS(unittest.TestCase):
         )
         self.assertIsNone(request, "Request should be None for future dates.")
 
-    def test_make_cds_request_era5_timeseries(self):
-        request = make_cds_request(
+    def test_make_cds_request_era5_timeseries_jan(self):
+        requests = make_cds_request(
             ds="reanalysis-era5-single-levels-timeseries",
             variables=["2m_temperature", "10m_u_component_of_wind"],
             year=2021,
             month=1,
             latitude=50.0,
             longitude=10.0,
-        )[0]
+        )
+        self.assertEqual(len(requests), 2)
 
-        self.assertEqual(request["dataset"], "reanalysis-era5-single-levels-timeseries")
-        self.assertIn("2m_temperature", request["variable"])
-        self.assertIn("10m_u_component_of_wind", request["variable"])
-        self.assertEqual(request["date"], ["2021-01-01/2021-01-31"])
-        self.assertEqual(request["location"], {"latitude": 50.0, "longitude": 10.0})
+        prev_day_request = requests[0]
+        self.assertEqual(prev_day_request["dataset"], "reanalysis-era5-single-levels-timeseries")
+        self.assertIn("2m_temperature", prev_day_request["variable"])
+        self.assertIn("10m_u_component_of_wind", prev_day_request["variable"])
+        self.assertEqual(prev_day_request["date"], ["2020-12-31/2020-12-31"])
+        self.assertEqual(prev_day_request["location"], {"latitude": 50.0, "longitude": 10.0})
+
+        main_request = requests[1]
+        self.assertEqual(main_request["date"], ["2021-01-01/2021-01-31"])
 
     def test_make_cds_request_era5_timeseries_full_year(self):
-        request = make_cds_request(
+        prev_day_request = make_cds_request(
             ds="reanalysis-era5-single-levels-timeseries",
             variables=["2m_temperature", "10m_u_component_of_wind"],
             year=2021,
@@ -83,19 +95,22 @@ class TestCDS(unittest.TestCase):
             latitude=50.0,
             longitude=10.0,
         )[0]
-        self.assertEqual(request["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(prev_day_request["date"], ["2020-12-31/2020-12-31"])
 
         now = now_utc()
-        request = make_cds_request(
+        requests = make_cds_request(
             ds="reanalysis-era5-single-levels-timeseries",
             variables=["2m_temperature", "10m_u_component_of_wind"],
             year=now.year,
             month=None,
             latitude=50.0,
             longitude=10.0,
-        )[0]
+        )
+        prev_day_request = requests[0]
+        main_request = requests[1]
+        self.assertEqual(prev_day_request["date"], [f"{now.year -1}-12-31/{now.year -1}-12-31"])
         self.assertEqual(
-            request["date"], [f"{now.year}-01-01/{now.year}-{now.month:02d}-{now.day:02d}"]
+            main_request["date"], [f"{now.year}-01-01/{now.year}-{now.month:02d}-{now.day:02d}"]
         )
 
     def test_make_cds_request_single_level_with_time_zone(self):

--- a/tests/test_time_zone.py
+++ b/tests/test_time_zone.py
@@ -54,9 +54,9 @@ class TestTimeZoneHandling(unittest.TestCase):
             longitude=10.0,
             time_zone=None,
         )
-        self.assertEqual(1, len(request))
-        self.assertEqual(request[0]["dataset"], "reanalysis-era5-single-levels-timeseries")
-        self.assertEqual(request[0]["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(2, len(request))
+        self.assertEqual(request[0]["date"], ["2020-12-31/2020-12-31"])
+        self.assertEqual(request[1]["date"], ["2021-01-01/2021-12-31"])
 
     def test_make_cams_request_with_positive_time_zone(self):
         """Test that positive time zone adds a day at the end for CAMS."""
@@ -78,7 +78,7 @@ class TestTimeZoneHandling(unittest.TestCase):
             time_zone=-8,  # -8 hours from UTC
         )
 
-        self.assertEqual(request["date"], ["2021-01-01/2022-01-01"])
+        self.assertEqual(request["date"], ["2020-12-31/2022-01-01"])
 
     def test_make_cams_request_without_time_zone(self):
         """Test that without time zone, the date range is unchanged for CAMS."""
@@ -89,7 +89,7 @@ class TestTimeZoneHandling(unittest.TestCase):
             time_zone=None,
         )
 
-        self.assertEqual(request["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(request["date"], ["2020-12-31/2021-12-31"])
 
     def test_make_cams_request_with_zero_time_zone(self):
         """Test that zero time zone doesn't add extra days."""
@@ -100,7 +100,7 @@ class TestTimeZoneHandling(unittest.TestCase):
             time_zone=0,  # UTC
         )
 
-        self.assertEqual(request["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(request["date"], ["2020-12-31/2021-12-31"])
 
     def test_make_cds_request_with_zero_time_zone(self):
         """Test that zero time zone doesn't add extra days."""
@@ -114,5 +114,6 @@ class TestTimeZoneHandling(unittest.TestCase):
             time_zone=0,  # UTC
         )
 
-        self.assertEqual(1, len(request))
+        self.assertEqual(2, len(request))
         self.assertEqual(request[0]["date"], ["2021-01-01/2021-12-31"])
+        self.assertEqual(request[1]["date"], ["2020-12-31/2020-12-31"])


### PR DESCRIPTION
Fixes #6 and #5

This PR introduces a `--apply-time-zone-to-data` option that will fetch extra data from CDS and ADS apis, and apply time zone to the merged df.

It also fixes a problem where first hour of the year was missing (even without tz).